### PR TITLE
Remove ansible_hostname from index.html template

### DIFF
--- a/exercises/exercise3/roles/apache/templates/index.html.j2
+++ b/exercises/exercise3/roles/apache/templates/index.html.j2
@@ -1,5 +1,5 @@
 {{ apache_test_message }} {{ ansible_distribution }} {{ ansible_distribution_version }}  <br>
-Current Host: {{ ansible_hostname }} <br>
+Current Host: <br>
 Server list: <br>
 {% for host in groups['web'] %}
 {{ host }} <br>


### PR DESCRIPTION
To be consistent with the README interactivity
